### PR TITLE
Close files immediately after extracting

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,23 @@ func toUtf8(str string, t transform.Transformer) (string, error) {
 	return string(ret), err
 }
 
+func extractItem(item *zip.File, path string) error {
+	output, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+	fp, err := item.Open()
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+	if _, err := io.Copy(output, fp); err != nil {
+		return err
+	}
+	return nil
+}
+
 func unzip(src, dest string, t transform.Transformer) error {
 	zc, err := zip.OpenReader(src)
 	if err != nil {
@@ -42,17 +59,7 @@ func unzip(src, dest string, t transform.Transformer) error {
 				return err
 			}
 		} else {
-			output, err := os.Create(path)
-			if err != nil {
-				return err
-			}
-			defer output.Close()
-			fp, err := item.Open()
-			if err != nil {
-				return err
-			}
-			defer fp.Close()
-			if _, err := io.Copy(output, fp); err != nil {
+			if err := extractItem(item, path); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Prevents `open some/path/to/some/file: too many open files` from happening.

The `defer` statement in Go executes deferred calls when the function in which it was used returns. In this case, since all files in the archive were being extracted in a loop inside a single function, it kept handles for all archived files open until the whole archive got extracted.